### PR TITLE
Fixed a bug with grep searching for fstab entry with `"` optional by `?`.

### DIFF
--- a/usbmount
+++ b/usbmount
@@ -106,7 +106,7 @@ if [ "$1" = add ]; then
 	log info "executing command: mount $DEVNAME"
 	mount $DEVNAME || log err "mount by DEVNAME with $DEVNAME wasn't successful; return code $?"
 
-    elif grep -q "^[[:blank:]]*UUID=\"?$UUID\"?" /etc/fstab; then
+    elif egrep -q "^[[:blank:]]*UUID=\"?$UUID\"?" /etc/fstab; then
         log info "executing command: mount -U $UUID"
 	mount -U $UUID || log err "mount by UUID with $UUID wasn't successful; return code $?"
 


### PR DESCRIPTION
Fixed a bug with grep searching for fstab entry with `"` optional by `?`. Need to call egrep (or grep -E with "ERE" syntax).